### PR TITLE
Interpret NA as FALSE in verify()

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -509,6 +509,8 @@ verify <- function(data, expr, success_fun=success_continue,
   envir <- data
   enclos <- parent.frame()
   logical.results <- eval(expr, envir, enclos)
+  # NAs are very likely errors, and cause problems in the all() below.
+  logical.results <- ifelse(is.na(logical.results), FALSE, logical.results)
 
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -120,6 +120,9 @@ test_that("verify raises error if verification fails", {
                 "verification \\[a >= 2 | b > 4\\] failed! \\(1 failure\\)")
   expect_output(verify(alist, 2 > 4, error_fun = just.show.error),
                 "verification \\[2 > 4\\] failed! \\(1 failure\\)")
+  # NA values don't compare TRUE
+  expect_output(verify(test.df2, z > -2, , error_fun = just.show.error),
+                "verification \\[z > -2\\] failed! \\(1 failure\\)")
 })
 
 test_that("verify breaks appropriately", {
@@ -714,5 +717,3 @@ test_that("verify works with chaining", {
   }
   expect_output(code_to_test(), "There are 2 errors")
 })
-
-


### PR DESCRIPTION
Thanks again for a great package!

Currently NA values in a `verify` expression cause trouble because [`all(logical.results)`](https://github.com/ropensci/assertr/blob/f732d54ef7eb6ef5a8e7b8213b887918f7e81650/R/assertions.R#L527) comes up as NA if any of `logical.results` are NA. I added a simple `ifelse` to turn NAs into FALSEs, but I'd be happy to change this to something else if you'd prefer.  (One option would be an error message specifically about NAs.)  What do you think?