### PR TITLE
Add tests for has_all_names and fix warnings in verify

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -515,7 +515,6 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
 verify <- function(data, expr, success_fun=success_continue,
                    error_fun=error_stop){
   expr <- substitute(expr)
-  # expr <- rlang::enexpr(expr)
   # conform to terminology from subset
   envir <- data
   enclos <- parent.frame()
@@ -536,13 +535,11 @@ verify <- function(data, expr, success_fun=success_continue,
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){
     if(!identical(success_fun, success_fun_override))
-      # warning("user defined success_fun overridden by assertr chain")
     success_fun <- success_fun_override
   }
   error_fun_override <- attr(data, "assertr_in_chain_error_fun_override")
   if(!is.null(error_fun_override)){
     if(!identical(error_fun, error_fun_override))
-      # warning("user defined error_fun overriden by assertr chain")
     error_fun <- error_fun_override
   }
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -515,6 +515,7 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
 verify <- function(data, expr, success_fun=success_continue,
                    error_fun=error_stop){
   expr <- substitute(expr)
+  # expr <- rlang::enexpr(expr)
   # conform to terminology from subset
   envir <- data
   enclos <- parent.frame()
@@ -523,14 +524,13 @@ verify <- function(data, expr, success_fun=success_continue,
   # NAs are very likely errors, and cause problems in the all() below.
   logical.results <- ifelse(is.na(logical.results), FALSE, logical.results)
 
-  # TODO: Are these checks helpful? Is this how they should be reported?
   if (!is.logical(logical.results)) {
-    warning(sprintf("The result of evaluating '", deparse(expr),
-      "' is not a logical vector"))
+    warning("The result of evaluating '", deparse(expr),
+      "' is not a logical vector")
   }
   if (length(logical.results) == 0) {
-    warning(sprintf("The result of evaluating '", deparse(expr),
-      "' has length zero"))
+    warning("The result of evaluating '", deparse(expr),
+      "' has length zero")
   }
 
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")

--- a/tests/testthat/test-utils.r
+++ b/tests/testthat/test-utils.r
@@ -1,0 +1,33 @@
+context("assertions about utils in utils.R")
+
+
+
+# Setup
+just.show.error <- function(err, ...){
+  lapply(err, summary)
+}
+
+
+
+### has_all_names ###
+
+test_that("has_all_names works with verify", {
+  # code borrowed from the has_all_names examples
+  expect_equal(verify(mtcars, has_all_names("mpg", "wt", "qsec")), mtcars)
+  expect_equal(mtcars %>% verify(has_all_names("mpg", "wt", "qsec")), mtcars)
+
+  mpgg <- "something"
+  expect_equal(verify(mtcars, exists("mpgg")), mtcars)  # passes but big mistake
+
+  expect_output(
+    mtcars %>% verify(has_all_names("mpgg"), error_fun = just.show.error),
+    "verification [has_all_names(\"mpgg\")] failed! (1 failure)",
+    fixed = TRUE)
+
+  # Same tests, but using variables to hold varnames
+  # code borrowed from the has_all_names examples
+  mpg_var <- "mpg"
+  wt_var <- "wt"
+  expect_equal(verify(mtcars, has_all_names(mpg_var, wt_var)), mtcars)
+  expect_equal(mtcars %>% verify(has_all_names(mpg_var, wt_var)), mtcars)
+})


### PR DESCRIPTION
The syntax was wrong in the `verify` code (mixing up `sprintf` and `warning` arguments).

Also, here are some tests for `has_all_names` that didn't make it into the last PR.