### PR TITLE
Allow is_uniq to take multiple arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ BugReports: https://github.com/ropensci/assertr/issues
 License: MIT + file LICENSE
 ByteCompile: TRUE
 LazyData: TRUE
+Depends: R (>= 3.1.0)
 Imports:
     dplyr (>= 0.7.0),
     MASS,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+
+# assertr 2.5
+
+* `is_uniq` predicate now accepts multiple vectors and evaluates uniqueness on the combination of them.
+
+* Breaking change: the `allow.na` argument to `is_uniq` must be named. Code like `is_uniq(x, TRUE)` will no longer work. Instead write `is_uniq(x, allow.na = TRUE)`.
+
 # assertr 2.4
 
 * errors from all assertr verbs now contain a data.frame holding the
@@ -71,4 +78,3 @@
 # assertr 0.2
 
 * initial release
-

--- a/man/is_uniq.Rd
+++ b/man/is_uniq.Rd
@@ -4,10 +4,10 @@
 \alias{is_uniq}
 \title{Returns TRUE where no elements appear more than once}
 \usage{
-is_uniq(x, allow.na = FALSE)
+is_uniq(..., allow.na = FALSE)
 }
 \arguments{
-\item{x}{A vector to check for unique elements in}
+\item{...}{One or more vectors to check for unique combinations of elements}
 
 \item{allow.na}{A logical indicating whether NAs should be preserved
 as missing values in the return value (FALSE) or
@@ -29,6 +29,7 @@ of a duplicated value as "non unique", as well.
 \examples{
 
 is_uniq(1:10)
+is_uniq(c(1,1,2,3), c(1,2,2,3))
 
 \dontrun{
 # returns FALSE where a "5" appears

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -849,3 +849,32 @@ test_that("all assertions work with !! unquoting", {
     error_fun = just.show.error),
     "Column 'x' violates assertion 'within_n_sds(3/10)' 2 times", fixed = TRUE)
 })
+
+test_that("verify works with variable-argument-length is_uniq", {
+  # These x, y, z should not be used by the is_uniq below because the
+  # predicates use a data mask
+  x <- 2:4
+  y <- 0:2
+  z <- 3
+  varname <- rlang::quo(x)
+
+  # test.df2 <- data.frame(x = c(0, 1, 2),
+  #                        y = c(2, 1.5, 1),
+  #                        z = c(0,NA, -1))
+  expect_equal(verify(test.df2, is_uniq(x)), test.df2)
+  expect_equal(verify(test.df2, is_uniq(x, y)), test.df2)
+  expect_equal(verify(test.df2, is_uniq(x, y, z, allow.na=TRUE)), test.df2)
+  expect_equal(verify(test.df2, is_uniq(!!varname)), test.df2)
+
+  df_dups <- data.frame(x = c(0, 0, 1, 2),
+                             y = c(1, 2, 2, NA),
+                             z = c(1, 1, 2, 3))
+  expect_output(verify(df_dups, is_uniq(x, z), error_fun = just.show.error),
+    "verification [is_uniq(x, z)] failed! (2 failures)", fixed = TRUE)
+  expect_equal(verify(df_dups, is_uniq(x, y, allow.na = TRUE)), df_dups)
+  expect_output(verify(df_dups, is_uniq(x, y), error_fun = just.show.error),
+    "verification [is_uniq(x, y)] failed! (1 failure)", fixed = TRUE)
+
+
+
+})

--- a/tests/testthat/test-predicates.R
+++ b/tests/testthat/test-predicates.R
@@ -292,7 +292,17 @@ test_that("is_uniq errors out when appropriate", {
   expect_error(is_uniq(c()),
                "is_uniq must be called on non-null object")
   expect_error(is_uniq(),
-               ".x. is missing")
+               "is_uniq must be called with some arguments")
+  # Check for argument length too
+  expect_error(is_uniq(1:2, 1:3),
+               "is_uniq must be called with vectors of all the same length")
+  expect_error(is_uniq(1:2, 1),
+               "is_uniq must be called with vectors of all the same length")
+  expect_error(is_uniq(NULL), "is_uniq must be called on non-null objects")
+  expect_error(is_uniq(1, NULL), "is_uniq must be called on non-null objects")
+  # Note that this would have been a perfectly fine call before is_uniq
+  # supported multiple vectors. The FALSE would match the allow.na argument
+  expect_error(is_uniq(1:2, FALSE))
 })
 
 test_that("predicate is tagged for assert function to vectorize", {
@@ -302,4 +312,36 @@ test_that("predicate is tagged for assert function to vectorize", {
 test_that("predicate appropriately assigns the 'call' attribute", {
   expect_equal(attr(is_uniq, "call"), "is_uniq")
 })
+
+test_that("is_uniq works with multiple vectors", {
+  v1 <- c("a", "b", "b", "c")
+  v2 <- c(1, 1, 2, 3)
+  v3 <- c(1, 2, 2, 3)
+  v4 <- c(1, NA, 2, 3)
+  list_col <- list(list(1, 2), list(1, 2), list(3,4), list("b"))
+  expect_equal(is_uniq(list_col), c(FALSE, FALSE, TRUE, TRUE))
+  expect_equal(is_uniq(v1, v1), c(TRUE, FALSE, FALSE, TRUE))
+  expect_equal(is_uniq(v1, v2), c(TRUE, TRUE, TRUE, TRUE))
+  expect_equal(is_uniq(v1, v3), c(TRUE, FALSE, FALSE, TRUE))
+  expect_equal(is_uniq(v1, v4), c(TRUE, NA, TRUE, TRUE))
+  expect_equal(is_uniq(v1, v4, allow.na = TRUE), c(TRUE, TRUE, TRUE, TRUE))
+  # Test numeric to numeric
+  expect_equal(is_uniq(v3, v4), c(TRUE, NA, TRUE, TRUE))
+  expect_equal(is_uniq(v4, v4, allow.na = TRUE), c(TRUE, TRUE, TRUE, TRUE))
+
+  # test lists
+  expect_equal(is_uniq(list_col, list_col), c(FALSE, FALSE, TRUE, TRUE))
+  expect_equal(is_uniq(list_col, v2), c(FALSE, FALSE, TRUE, TRUE))
+  expect_equal(is_uniq(list_col, v3), c(TRUE, TRUE, TRUE, TRUE))
+  expect_equal(is_uniq(list_col, v4), c(TRUE, NA, TRUE, TRUE))
+  expect_equal(is_uniq(list_col, v4, allow.na = TRUE), c(TRUE, TRUE, TRUE, TRUE))
+
+  # Test >2 vectors
+  expect_equal(is_uniq(v1, v2, v3), c(TRUE, TRUE, TRUE, TRUE))
+  expect_equal(is_uniq(v1, v2, v4), c(TRUE, NA, TRUE, TRUE))
+  expect_equal(is_uniq(v1, v2, v4, allow.na = TRUE), c(TRUE, TRUE, TRUE, TRUE))
+
+})
+
+
 ######################################


### PR DESCRIPTION
- Depend on R 3.1.0 because I use `anyNA` (let me know if you want to support older R versions; I could use the less efficient `any(is.na())` instead.
- It seems silly to write  `!(duplicated(dots_df) | duplicated(dots_df, fromLast = TRUE))`, but the alternative of finding which rows are duplicated is messier. (I haven't compared speeds.)
- Add to NEWS because calling `is_uniq` without naming the `allow.na` argument will no longer work.
- Tests!

Fixes #66