### PR TITLE
Update rlang use

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Depends: R (>= 3.1.0)
 Imports:
     dplyr (>= 0.7.0),
     MASS,
-    lazyeval,
     stats,
     utils,
     rlang (>= 0.1.2)

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -58,7 +58,7 @@ assert <- function(data, predicate, ..., success_fun=success_continue,
                       error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.predicate <- lazyeval::expr_text(predicate)
+  name.of.predicate <- rlang::expr_text(predicate)
   if(!is.null(attr(predicate, "call"))){
     name.of.predicate <- attr(predicate, "call")
   }
@@ -172,8 +172,8 @@ assert_rows <- function(data, row_reduction_fn, predicate, ...,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.row.redux.fn <- lazyeval::expr_text(row_reduction_fn)
-  name.of.predicate <- lazyeval::expr_text(predicate)
+  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
+  name.of.predicate <- rlang::expr_text(predicate)
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }
@@ -227,7 +227,8 @@ assert_rows <- function(data, row_reduction_fn, predicate, ...,
 
 
 
-#' Raises error if dynamically created predicate is FALSE in any columns selected
+#' Raises error if dynamically created predicate is FALSE in any columns
+#' selected
 #'
 #' Meant for use in a data analysis pipeline, this function applies a predicate
 #' generating function to each of the columns indicated. It will then use these
@@ -284,7 +285,7 @@ insist <- function(data, predicate_generator, ...,
                     error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.predicate.generator <- lazyeval::expr_text(predicate_generator)
+  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
   if(!is.null(attr(predicate_generator, "call"))){
     name.of.predicate.generator <- attr(predicate_generator, "call")
   }
@@ -403,8 +404,8 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.row.redux.fn <- lazyeval::expr_text(row_reduction_fn)
-  name.of.predicate.generator <- lazyeval::expr_text(predicate_generator)
+  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
+  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -58,7 +58,7 @@ assert <- function(data, predicate, ..., success_fun=success_continue,
                       error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.predicate <- rlang::expr_text(predicate)
+  name.of.predicate <- rlang::expr_text(rlang::enexpr(predicate))
   if(!is.null(attr(predicate, "call"))){
     name.of.predicate <- attr(predicate, "call")
   }
@@ -172,8 +172,8 @@ assert_rows <- function(data, row_reduction_fn, predicate, ...,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
-  name.of.predicate <- rlang::expr_text(predicate)
+  name.of.row.redux.fn <- rlang::expr_text(rlang::enexpr(row_reduction_fn))
+  name.of.predicate <- rlang::expr_text(rlang::enexpr(predicate))
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }
@@ -285,7 +285,8 @@ insist <- function(data, predicate_generator, ...,
                     error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
+  name.of.predicate.generator <- rlang::expr_text(
+      rlang::enexpr(predicate_generator))
   if(!is.null(attr(predicate_generator, "call"))){
     name.of.predicate.generator <- attr(predicate_generator, "call")
   }
@@ -404,8 +405,9 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
   sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
-  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
-  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
+  name.of.row.redux.fn <- rlang::expr_text(rlang::enexpr(row_reduction_fn))
+  name.of.predicate.generator <- rlang::expr_text(
+      rlang::enexpr(predicate_generator))
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }
@@ -515,12 +517,9 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
 #' @export
 verify <- function(data, expr, success_fun=success_continue,
                    error_fun=error_stop){
-  expr <- substitute(expr)
-  # conform to terminology from subset
-  envir <- data
-  enclos <- parent.frame()
+  expr <- rlang::enexpr(expr)
   # Use eval_tidy here to get the .data pronoun and all the eval_tidy benefits
-  logical.results <- rlang::eval_tidy(expr, envir, enclos)
+  logical.results <- rlang::eval_tidy(expr, data, parent.frame())
   # NAs are very likely errors, and cause problems in the all() below.
   logical.results <- ifelse(is.na(logical.results), FALSE, logical.results)
 

--- a/R/deprecated_se.R
+++ b/R/deprecated_se.R
@@ -1,5 +1,6 @@
 ##
-## this file contains the underscore-postfixed SE verbs, to be removed eventually
+## this file contains the underscore-postfixed SE verbs, to be removed
+## eventually
 ##
 
 #' @export
@@ -7,14 +8,15 @@
 #' @rdname assert
 assert_ <- function(data, predicate, ..., .dots, success_fun=success_continue,
                     error_fun=error_stop){
-  warning("`assert_` is deprecated and will eventually be removed from assertr. ",
+  warning("`assert_` is deprecated and will eventually be removed from assertr.
+          ",
           "Please use `assert` instead.", call. = FALSE)
   sub.frame <- dplyr::select_(data, ..., .dots = .dots)
-  name.of.predicate <- lazyeval::expr_text(predicate)
+  name.of.predicate <- rlang::expr_text(predicate)
   if(!is.null(attr(predicate, "call"))){
     name.of.predicate <- attr(predicate, "call")
   }
-  
+
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){
     if(!identical(success_fun, success_fun_override))
@@ -27,22 +29,22 @@ assert_ <- function(data, predicate, ..., .dots, success_fun=success_continue,
       # warning("user defined error_fun overriden by assertr chain")
       error_fun <- error_fun_override
   }
-  
-  
+
+
   if(!is.vectorized.predicate(predicate))
     predicate <- make.predicate.proper(predicate)
-  
-  
+
+
   log.mat <- sapply(names(sub.frame),
                     function(column){
                       this.vector <- sub.frame[[column]]
                       return(apply.predicate.to.vector(this.vector,
                                                        predicate))})
-  
+
   # if all checks pass *and* there are no leftover errors
   if(all(log.mat) && is.null(attr(data, "assertr_errors")))
     return(success_fun(data))
-  
+
   errors <- lapply(colnames(log.mat), function(col.name){
     col <- log.mat[, col.name]
     num.violations <- sum(!col)
@@ -57,7 +59,7 @@ assert_ <- function(data, predicate, ..., .dots, success_fun=success_continue,
                                           offending.elements)
     return(an_error)
   })
-  
+
   # remove the elements corresponding to the columns without errors
   errors <- Filter(function(x) !is.null(x), errors)
   error_fun(errors, data=data)
@@ -69,18 +71,19 @@ assert_ <- function(data, predicate, ..., .dots, success_fun=success_continue,
 assert_rows_ <- function(data, row_reduction_fn, predicate, ..., .dots,
                          success_fun=success_continue,
                          error_fun=error_stop){
-  warning("`assert_rows_` is deprecated and will eventually be removed from assertr. ",
+  warning("`assert_rows_` is deprecated and will eventually be removed from
+          assertr. ",
           "Please use `assert_rows` instead.", call. = FALSE)
   sub.frame <- dplyr::select_(data, ..., .dots = .dots)
-  name.of.row.redux.fn <- lazyeval::expr_text(row_reduction_fn)
-  name.of.predicate <- lazyeval::expr_text(predicate)
+  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
+  name.of.predicate <- rlang::expr_text(predicate)
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }
   if(!is.null(attr(predicate, "call"))){
     name.of.predicate <- attr(predicate, "call")
   }
-  
+
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){
     if(!identical(success_fun, success_fun_override))
@@ -93,18 +96,18 @@ assert_rows_ <- function(data, row_reduction_fn, predicate, ..., .dots,
       # warning("user defined error_fun overriden by assertr chain")
       error_fun <- error_fun_override
   }
-  
+
   if(!is.vectorized.predicate(predicate))
     predicate <- make.predicate.proper(predicate)
-  
+
   redux <- row_reduction_fn(sub.frame)
-  
+
   log.vec <- apply.predicate.to.vector(redux, predicate)
-  
+
   # if all checks pass *and* there are no leftover errors
   if(all(log.vec) && is.null(attr(data, "assertr_errors")))
     return(success_fun(data))
-  
+
   num.violations <- sum(!log.vec)
   if(num.violations==0)
     # There are errors, just no new ones, so calling success
@@ -112,13 +115,13 @@ assert_rows_ <- function(data, row_reduction_fn, predicate, ..., .dots,
     # NOT calling either function would break the pipeline.
     return(error_fun(list(), data=data))
   loc.violations <- which(!log.vec)
-  
+
   error <- make.assertr.assert_rows.error(name.of.row.redux.fn,
                                           name.of.predicate,
                                           num.violations,
                                           loc.violations)
   error_fun(list(error), data=data)
-  
+
 }
 
 #' @export
@@ -127,14 +130,15 @@ assert_rows_ <- function(data, row_reduction_fn, predicate, ..., .dots,
 insist_ <- function(data, predicate_generator, ..., .dots,
                     success_fun=success_continue,
                     error_fun=error_stop){
-  warning("`insist_` is deprecated and will eventually be removed from assertr. ",
+  warning("`insist_` is deprecated and will eventually be removed from assertr.
+          ",
           "Please use `insist` instead.", call. = FALSE)
   sub.frame <- dplyr::select_(data, ..., .dots = .dots)
-  name.of.predicate.generator <- lazyeval::expr_text(predicate_generator)
+  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
   if(!is.null(attr(predicate_generator, "call"))){
     name.of.predicate.generator <- attr(predicate_generator, "call")
   }
-  
+
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){
     if(!identical(success_fun, success_fun_override))
@@ -147,22 +151,22 @@ insist_ <- function(data, predicate_generator, ..., .dots,
       # warning("user defined error_fun overriden by assertr chain")
       error_fun <- error_fun_override
   }
-  
+
   # get true predicates (not the generator)
   true.predicates <- sapply(names(sub.frame),
                             function(column){predicate_generator(sub.frame[[column]])})
-  
+
   log.mat <- sapply(names(sub.frame),
                     function(column){
                       this.vector <- sub.frame[[column]]
                       predicate <- true.predicates[[column]]
                       return(apply.predicate.to.vector(this.vector,
                                                        predicate))})
-  
+
   # if all checks pass *and* there are no leftover errors
   if(all(log.mat) && is.null(attr(data, "assertr_errors")))
     return(success_fun(data))
-  
+
   errors <- lapply(colnames(log.mat), function(col.name){
     col <- log.mat[, col.name]
     num.violations <- sum(!col)
@@ -177,10 +181,10 @@ insist_ <- function(data, predicate_generator, ..., .dots,
                                           offending.elements)
     return(an_error)
   })
-  
+
   # remove the elements corresponding to the columns without errors
   errors <- Filter(function(x) !is.null(x), errors)
-  
+
   error_fun(errors, data=data)
 }
 
@@ -190,20 +194,21 @@ insist_ <- function(data, predicate_generator, ..., .dots,
 insist_rows_ <- function(data, row_reduction_fn, predicate_generator, ...,
                          .dots, success_fun=success_continue,
                          error_fun=error_stop){
-  warning("`insist_rows_` is deprecated and will eventually be removed from assertr. ",
+  warning("`insist_rows_` is deprecated and will eventually be removed from
+          assertr. ",
           "Please use `insist_rows` instead.", call. = FALSE)
   sub.frame <- dplyr::select_(data, ..., .dots = .dots)
-  
-  
-  name.of.row.redux.fn <- lazyeval::expr_text(row_reduction_fn)
-  name.of.predicate.generator <- lazyeval::expr_text(predicate_generator)
+
+
+  name.of.row.redux.fn <- rlang::expr_text(row_reduction_fn)
+  name.of.predicate.generator <- rlang::expr_text(predicate_generator)
   if(!is.null(attr(row_reduction_fn, "call"))){
     name.of.row.redux.fn <- attr(row_reduction_fn, "call")
   }
   if(!is.null(attr(predicate_generator, "call"))){
     name.of.predicate.generator <- attr(predicate_generator, "call")
   }
-  
+
   success_fun_override <- attr(data, "assertr_in_chain_success_fun_override")
   if(!is.null(success_fun_override)){
     if(!identical(success_fun, success_fun_override))
@@ -216,17 +221,17 @@ insist_rows_ <- function(data, row_reduction_fn, predicate_generator, ...,
       # warning("user defined error_fun overriden by assertr chain")
       error_fun <- error_fun_override
   }
-  
+
   redux <- row_reduction_fn(sub.frame)
-  
+
   predicate <- predicate_generator(redux)
-  
+
   log.vec <- apply.predicate.to.vector(redux, predicate)
-  
+
   # if all checks pass *and* there are no leftover errors
   if(all(log.vec) && is.null(attr(data, "assertr_errors")))
     return(success_fun(data))
-  
+
   num.violations <- sum(!log.vec)
   if(num.violations==0)
     # There are errors, just no new ones, so calling success
@@ -234,7 +239,7 @@ insist_rows_ <- function(data, row_reduction_fn, predicate_generator, ...,
     # NOT calling either function would break the pipeline.
     return(error_fun(list(), data=data))
   loc.violations <- which(!log.vec)
-  
+
   error <- make.assertr.assert_rows.error(name.of.row.redux.fn,
                                           name.of.predicate.generator,
                                           num.violations,

--- a/codemeta.json
+++ b/codemeta.json
@@ -100,17 +100,6 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "lazyeval",
-      "name": "lazyeval",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      }
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "stats",
       "name": "stats"
     },

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -137,6 +137,15 @@ test_that("verify breaks appropriately", {
   expect_error(verify(mtcars, 1 > 0, "tree"), "could not find function \"success_fun\"")
   expect_error(verify(mtcars, d > 1), "object 'd' not found")
 })
+
+test_that("verify works within functions", {
+  my_verify <- function(data, expr, success_fun) {
+    verify(data, !!rlang::enexpr(expr), success_fun=success_fun)
+  }
+
+  expect_true(my_verify(mtcars, drat > 2, success_fun=success_logical))
+})
+
 ######################################
 
 
@@ -198,7 +207,7 @@ test_that("assert breaks appropriately", {
   expect_error(assert(in_set(0,1), mtcars$vs),
                "no applicable method for 'select.?' applied to an object of class \"function\"")
   expect_error(assert(mtcars, in_set(0,1), vs, tree),
-               "object 'tree' not found")
+               "`tree` must resolve to integer column positions")
   expect_error(assert(mtcars, in_set(0,1), vs, "tree"))
   expect_error(assert("tree"),
                "no applicable method for 'select.?' applied to an object of class \"character\"")
@@ -264,7 +273,7 @@ test_that("assert_rows breaks appropriately", {
   expect_error(assert_rows(rowSums, in_set(0,1), mtcars$vs),
                "no applicable method for 'select.?' applied to an object of class \"function\"")
   expect_error(assert_rows(mtcars, rowSums, in_set(0,1,2), vs, am, tree),
-               "object 'tree' not found")
+               "`tree` must resolve to integer column positions")
   expect_error(assert_rows(mtcars, rowSums, in_set(0,1,2), vs, am, "tree"))
   expect_error(assert_rows("tree"),
                "no applicable method for 'select.?' applied to an object of class \"character\"")
@@ -315,7 +324,7 @@ test_that("insist breaks appropriately", {
                "no applicable method for 'select.?' applied to an object of class \"function\"")
   expect_error(insist(mtcars, within_n_sds(5), "vs:am"))
   expect_error(insist(mtcars, within_n_sds(5), tree),
-               "object 'tree' not found")
+               "`tree` must resolve to integer column positions")
   expect_error(insist("tree"),
                "no applicable method for 'select.?' applied to an object of class \"character\"")
   expect_error(insist(iris, within_n_sds(5), Petal.Width:Species),


### PR DESCRIPTION
This PR standardizes calls to rlang in the package. It

- removes the need to use lazyeval
- fixes uses of rlang that weren't complete

The most notable change is that verify now works within other functions. This lets users wrap it in their own helper, (for example) setting the default error or success function.