### PR TITLE
Fix bugs due to changes in rlang 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     MASS,
     stats,
     utils,
-    rlang (>= 0.1.2)
+    rlang (>= 0.3.0)
 Suggests:
     knitr,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: assertr
 Type: Package
 Title: Assertive Programming for R Analysis Pipelines
-Version: 2.5.5
+Version: 2.5.6
 Authors@R: person("Tony", "Fischetti",
               email="tony.fischetti@gmail.com",
               role = c("aut", "cre"))

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+# assertr 2.6
+
+* bugs due to changes in rlang 0.3.0 fixed.
 
 # assertr 2.5
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -57,7 +57,7 @@
 assert <- function(data, predicate, ..., success_fun=success_continue,
                       error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
-  sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
+  sub.frame <- dplyr::select(data, !!!(keeper.vars))
   name.of.predicate <- rlang::expr_text(rlang::enexpr(predicate))
   if(!is.null(attr(predicate, "call"))){
     name.of.predicate <- attr(predicate, "call")
@@ -171,7 +171,7 @@ assert_rows <- function(data, row_reduction_fn, predicate, ...,
                          success_fun=success_continue,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
-  sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
+  sub.frame <- dplyr::select(data, !!!(keeper.vars))
   name.of.row.redux.fn <- rlang::expr_text(rlang::enexpr(row_reduction_fn))
   name.of.predicate <- rlang::expr_text(rlang::enexpr(predicate))
   if(!is.null(attr(row_reduction_fn, "call"))){
@@ -284,7 +284,7 @@ insist <- function(data, predicate_generator, ...,
                     success_fun=success_continue,
                     error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
-  sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
+  sub.frame <- dplyr::select(data, !!!(keeper.vars))
   name.of.predicate.generator <- rlang::expr_text(
       rlang::enexpr(predicate_generator))
   if(!is.null(attr(predicate_generator, "call"))){
@@ -404,7 +404,7 @@ insist_rows <- function(data, row_reduction_fn, predicate_generator, ...,
                          success_fun=success_continue,
                          error_fun=error_stop){
   keeper.vars <- dplyr::quos(...)
-  sub.frame <- dplyr::select(data, rlang::UQS(keeper.vars))
+  sub.frame <- dplyr::select(data, !!!(keeper.vars))
   name.of.row.redux.fn <- rlang::expr_text(rlang::enexpr(row_reduction_fn))
   name.of.predicate.generator <- rlang::expr_text(
       rlang::enexpr(predicate_generator))

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,6 +75,7 @@ apply.predicate.to.vector <- function(a.column, predicate){
 has_all_names <- function(...){
   check_this <- list(...)
   parent <- parent.frame()
-  given_names <- names(parent$.top_env$.data)
+  given_names <- rlang::env_names(parent$.top_env)
+  given_names <- given_names[given_names != ".data"]
   all(check_this %in% given_names)
 }


### PR DESCRIPTION
This fixes two bugs due to changes in rlang 0.3.0, namely 

> Calling `UQ()` and `UQS()` with the rlang namespace qualifier is deprecated as of rlang 0.3.0. [...] 

and 

> `names()` and `length()` methods for data pronouns are deprecated. It is no longer valid to write `names(.data)` or `length(.data)`

Tests with current master (e8a46a2b598d500a9e3c62d33487aeae9586979e)

```r
==> devtools::test()

Loading assertr
Testing assertr
v | OK F W S | Context
v | 221   1   | assertions about assertions in assertion.R [1.8 s]
-------------------------------------------------------------------------
test-assertions.R:169: warning: assert returns data if verification passes
Prefixing `UQS()` with the rlang namespace is deprecated as of rlang 0.3.0.
Please use the non-prefixed form or `!!!` instead.

  # Bad:
  rlang::expr(mean(rlang::UQS(args)))

  # Ok:
  rlang::expr(mean(UQS(args)))

  # Good:
  rlang::expr(mean(!!!args))

This warning is displayed once per session.
-------------------------------------------------------------------------
v | 135       | assertions about predicates in predicates.R [0.2 s]
v | 29       | assertions about row reduction functions in row-redux.R
- |  0   1   | assertions about utils in utils.Rverification [has_all_names("mpg", "wt", "qsec")] failed! (1 failure)

    verb redux_fn                          predicate column index value
1 verify       NA has_all_names("mpg", "wt", "qsec")     NA     1    NA

x |  0 1 1   | assertions about utils in utils.R
-------------------------------------------------------------------------
test-utils.r:16: warning: has_all_names works with verify
Taking the `names()` of the `.data` pronoun is deprecated
This warning is displayed once per session.

test-utils.r:16: error: has_all_names works with verify
assertr stopped execution
1: expect_equal(verify(mtcars, has_all_names("mpg", "wt", "qsec")), mtcars) at C:\Users\daniel\Documents\R\github\assertr/tests/testthat/test-utils.r:16
2: quasi_label(enquo(object), label)
3: eval_bare(get_expr(quo), get_env(quo))
4: verify(mtcars, has_all_names("mpg", "wt", "qsec"))
5: error_fun(list(error), data = data) at C:/Users/daniel/Documents/R/github/assertr/R/assertions.R:554
6: stop("assertr stopped execution", call. = FALSE) at C:/Users/daniel/Documents/R/github/assertr/R/errors.R:240
-------------------------------------------------------------------------

== Results ==============================================================
Duration: 2.2 s

OK:       385
Failed:   1
Warnings: 2
Skipped:  0
```

Tests with fix_rlang_0.3 (34e10f5564784d49f43392ca0b5e403cbe536803)

```r
==> devtools::test()

Loading assertr
Testing assertr
v | OK F W S | Context
v | 221       | assertions about assertions in assertion.R [1.7 s]
v | 135       | assertions about predicates in predicates.R [0.2 s]
v | 29       | assertions about row reduction functions in row-redux.R
v |  6       | assertions about utils in utils.R

== Results ==============================================================
Duration: 2.1 s

OK:       391
Failed:   0
Warnings: 0
Skipped:  0

```
