### PR TITLE
assert: remove dead code (closes #103)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: assertr
 Type: Package
 Title: Assertive Programming for R Analysis Pipelines
-Version: 2.6.9000
+Version: 2.7
 Authors@R: person("Tony", "Fischetti",
               email="tony.fischetti@gmail.com",
               role = c("aut", "cre"))

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+# assertr 2.7
+
+* `assert()`: remove dead code (closes #103)
+
 # assertr 2.6
 
 * bugs due to changes in rlang 0.3.0 fixed.

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -107,11 +107,6 @@ assert <- function(data, predicate, ..., success_fun=success_continue,
                       return(apply.predicate.to.vector(this.vector,
                                                        predicate))})
 
-  if(class(log.mat)=="logical"){
-    log.mat <- matrix(log.mat)
-    colnames(log.mat) <- colnames(sub.frame)
-  }
-
   # if all checks pass in current assertion
   if(all(log.mat))
     return(success_fun(data, "assert", name.of.predicate, colnames(log.mat), NA, description))

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,6 +32,7 @@ is.vectorized.predicate <- function(predicate){
 
 apply.predicate.to.vector <- function(a.column, predicate){
   res <- logical(length(a.column))
+
   if(is.vectorized.predicate(predicate))
     res <- predicate(a.column)
   else

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -328,8 +328,13 @@ test_that("assert raises *custom error* if verification fails", {
 test_that("assert breaks appropriately", {
   expect_error(assert(in_set(0,1), mtcars$vs),
                "assert requires columns to be selected. Check number of arguments")
-  expect_error(assert(mtcars, in_set(0,1), vs, tree),
-               "object 'tree' not found")
+  expect_error(
+    object = {
+      assert(mtcars, in_set(0,1), vs, tree)
+      },
+    regexp = "Column `tree` doesn't exist",
+    class = "error"
+    )
   expect_error(assert(mtcars, in_set(0,1), vs, "tree"))
   expect_error(assert("tree"),
                "argument \"predicate\" is missing, with no default")
@@ -427,8 +432,20 @@ test_that("assert_rows breaks appropriately", {
                "argument \"predicate\" is missing, with no default")
   expect_error(assert_rows(rowSums, in_set(0,1), mtcars$vs),
                "assert_rows requires columns to be selected. Check number of arguments")
-  expect_error(assert_rows(mtcars, rowSums, in_set(0,1,2), vs, am, tree),
-               "object 'tree' not found")
+  expect_error(
+    object = {
+      assert_rows(
+        data = mtcars,
+        row_reduction_fn = rowSums,
+        predicate = in_set(0,1,2),
+        vs,
+        am,
+        tree
+        )
+      },
+    regexp = "Column `tree` doesn't exist",
+    class = "error"
+    )
   expect_error(assert_rows(mtcars, rowSums, in_set(0,1,2), vs, am, "tree"))
   expect_error(assert_rows("tree"),
                "argument \"row_reduction_fn\" is missing, with no default")
@@ -502,8 +519,13 @@ test_that("insist breaks appropriately", {
   expect_error(insist(within_n_sds(5), mtcars$vs),
                "insist requires columns to be selected. Check number of arguments")
   expect_error(insist(mtcars, within_n_sds(5), "vs:am"))
-  expect_error(insist(mtcars, within_n_sds(5), tree),
-               "object 'tree' not found")
+  expect_error(
+    object = {
+      insist(data = mtcars, predicate_generator = within_n_sds(5), tree)
+      },
+    regexp = "Column `tree` doesn't exist",
+    class = "error"
+    )
   expect_error(insist("tree"),
                "argument \"predicate_generator\" is missing, with no default")
   expect_error(insist(iris, within_n_sds(5), Petal.Width:Species),


### PR DESCRIPTION
Hello,
this looks like dead code to me.

My original solution was to use the recommended way of checking the class of an object:

`if(inherits(log.mat, "logical"))...`

However, I could not find a case in which this path was followed in the code. My understanding is that `sapply(colnames(sub.frame)...` returns an object of class "matrix" when the input is a data.frame, see my simple examples below:

```
x <- c(FALSE, TRUE)
out <- sapply(x, function(i){is.na(i)})
str(out)
class(out)


dt <- data.frame(
  a_bool = c(FALSE, TRUE)
)

out <- sapply(colnames(dt), function(i){this.vector <- dt[[i]]})
str(out)
class(out)
```

Should I be wrong, feel free to close my pull request.

Thank you for your time,
Angela
