### PR TITLE
Verify/silence test output

### DIFF
--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -1325,7 +1325,11 @@ test_that("all assertions work with .data pronoun without chains", {
 
   ## assert() ##
   expect_equal(assert(test.df, within_bounds(-Inf, 2), .data$x), test.df)
-  expect_error(assert(test.df, within_bounds(2, Inf), .data$x))
+  expect_output(
+    expect_error(assert(test.df, within_bounds(2, Inf), .data$x)),
+    regexp="Column 'x' violates assertion 'within_bounds(2, Inf)' 2 times",
+    fixed=TRUE
+  )
   # Cases where the name doesn't exist:
   expect_error(assert(test.df, within_bounds(-Inf, 2), .data$y))
   # Note that assert(test.df, within_bounds(-Inf, 2), y) would not work because


### PR DESCRIPTION
While working on #107, I noticed that one of the tests has output to the console.  This captures and tests for that output.  The main goal was to make the tests easier to review by making sure that you only see the tests results.  If the output is desired, then please feel free to close this PR without merging.