### PR TITLE
assert: handle non-vectorized predicates (closes #95)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,9 @@ Suggests:
     knitr,
     testthat,
     magrittr,
-    rmarkdown
+    rmarkdown,
+    tibble,
+    plyr
 VignetteBuilder: knitr
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+# assertr 2.8
+
+* `assert()`: handle non-vectorized predicates (closes #95)
+
 # assertr 2.7
 
 * `assert()`: remove dead code (closes #103)

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,8 @@
 # TRUE (and not NULL) if not FALSE
 make.predicate.proper <- function(improper.predicate){
   ret.fun <- function(x){
-    return(length(improper.predicate(x))==0 || improper.predicate(x))
+    ret <- improper.predicate(x)
+    return(length(ret) == 0 || ret)
   }
   if(is.vectorized.predicate(improper.predicate)){
     attr(ret.fun, "assertr_vectorized") <- TRUE

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -1602,3 +1602,15 @@ test_that("description is correctly stored and displayed in results", {
   )
 
 })
+
+test_that("handle predicates applied to the whole data, and not to subframe", {
+  a_tibble <- tibble::tibble(
+    a = c(0, 0),
+    b = c(0,0)
+  ) %>%
+    head( n = 0)
+
+  expect_silent({
+    assert(data = a_tibble, predicate = plyr::empty, dplyr::everything())
+  })
+})


### PR DESCRIPTION
Issue #95 was an interesting case. I guess most of the time the predicates are to be applied to each column of the data, whereas this case referred to the data as a whole.

This is my low level attempt to fix the issue. 
Hope this helps.

Kind regards,
Angela