### PR TITLE
Fix example

### DIFF
--- a/R/predicates.R
+++ b/R/predicates.R
@@ -361,7 +361,7 @@ within_n_mads <- function(n, ...){
 #' }
 #'
 #' # to use the version of this function that allows NAs in `assert`,
-#' you can use a lambda/anonymous function like so:
+#' # you can use a lambda/anonymous function like so:
 #'
 #' mtcars %>%
 #'   assert(function(x){is_uniq(x, allow.na=TRUE)}, qsec)


### PR DESCRIPTION
Just a missing `#` (seen via https://ropensci.r-universe.dev/ui#builds)