### PR TITLE
Allow any class for `within_bounds()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,5 +31,5 @@ Suggests:
     tibble,
     plyr
 VignetteBuilder: knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+# assertr development version
+
+* Added the ability to check non-numeric classes with `within_bounds()`
+  (fix #89)
+
 # assertr 3.0
 
 * Finally removed deprecated underscore functions

--- a/R/predicates.R
+++ b/R/predicates.R
@@ -50,6 +50,10 @@ attr(not_na, "call") <- "not_na"
 #'        should be inclusive (default TRUE)
 #' @param allow.na A logical indicating whether NAs (including NaNs)
 #'        should be permitted (default TRUE)
+#' @param check.class Should the class of the \code{lower.bound},
+#'        \code{upper_bound}, and the input to the returned function be checked
+#'        to be numeric or of the same class?  If \code{FALSE}, the comparison
+#'        may have unexpected results.
 #'
 #' @return A function that takes numeric value or numeric vactor and returns
 #'         TRUE if the value(s) is/are within the bounds defined by the
@@ -84,15 +88,20 @@ attr(not_na, "call") <- "not_na"
 #' @export
 within_bounds <- function(lower.bound, upper.bound,
                           include.lower=TRUE, include.upper=TRUE,
-                          allow.na=TRUE){
+                          allow.na=TRUE, check.class=TRUE){
   the_call <- deparse(sys.call())
-  if(!(is.numeric(lower.bound) && is.numeric(upper.bound)))
-    stop("bounds must be numeric")
+  numeric.bounds <- is.numeric(lower.bound) && is.numeric(upper.bound)
+  compatible.bounds <- class(lower.bound) %in% class(upper.bound)
+  if(check.class && !(numeric.bounds || compatible.bounds))
+    stop("bounds must be numeric or have similar classes")
   if(lower.bound >= upper.bound)
     stop("lower bound must be strictly lower than upper bound")
   fun <- function(x){
     if(is.null(x))       stop("bounds must be checked on non-null element")
-    if(!is.numeric(x))   stop("bounds must only be checked on numerics")
+    numeric.comparison <- is.numeric(lower.bound) && is.numeric(x)
+    compatible.comparison <- class(lower.bound) %in% class(x)
+    if(check.class && !(numeric.comparison || compatible.comparison))
+      stop("bounds must only be checked on numerics or classes that are similar")
     lower.operator <- if(!include.lower) `>` else `>=`
     upper.operator <- if(!include.upper) `<` else `<=`
     if(allow.na){

--- a/R/predicates.R
+++ b/R/predicates.R
@@ -96,14 +96,14 @@ within_bounds <- function(lower.bound, upper.bound,
     stop("bounds must be numeric or have similar classes")
   if(lower.bound >= upper.bound)
     stop("lower bound must be strictly lower than upper bound")
+  lower.operator <- if(!include.lower) `>` else `>=`
+  upper.operator <- if(!include.upper) `<` else `<=`
   fun <- function(x){
     if(is.null(x))       stop("bounds must be checked on non-null element")
     numeric.comparison <- is.numeric(lower.bound) && is.numeric(x)
     compatible.comparison <- class(lower.bound) %in% class(x)
     if(check.class && !(numeric.comparison || compatible.comparison))
       stop("bounds must only be checked on numerics or classes that are similar")
-    lower.operator <- if(!include.lower) `>` else `>=`
-    upper.operator <- if(!include.upper) `<` else `<=`
     if(allow.na){
       return((lower.operator(x, lower.bound) &
                 upper.operator(x, upper.bound)) | is.na(x))

--- a/man/within_bounds.Rd
+++ b/man/within_bounds.Rd
@@ -9,7 +9,8 @@ within_bounds(
   upper.bound,
   include.lower = TRUE,
   include.upper = TRUE,
-  allow.na = TRUE
+  allow.na = TRUE,
+  check.class = TRUE
 )
 }
 \arguments{
@@ -25,6 +26,11 @@ should be inclusive (default TRUE)}
 
 \item{allow.na}{A logical indicating whether NAs (including NaNs)
 should be permitted (default TRUE)}
+
+\item{check.class}{Should the class of the \code{lower.bound},
+\code{upper_bound}, and the input to the returned function be checked
+to be numeric or of the same class?  If \code{FALSE}, the comparison
+may have unexpected results.}
 }
 \value{
 A function that takes numeric value or numeric vactor and returns

--- a/tests/testthat/test-predicates.R
+++ b/tests/testthat/test-predicates.R
@@ -65,11 +65,16 @@ test_that("predicate appropriately assigns the 'call' attribute", {
 test_that("within_bounds fails appropriately", {
   expect_error(within_bounds(),
                ".lower.bound. is missing")
-  expect_error(within_bounds(1, "tree"), "bounds must be numeric")
+  expect_error(within_bounds(1, "tree"), "bounds must be numeric or have similar classes")
+  expect_silent(within_bounds(1, "tree", check.class=FALSE))
   expect_error(within_bounds(2, 1),
                "lower bound must be strictly lower than upper bound")
   expect_error(within_bounds(2, 2),
                "lower bound must be strictly lower than upper bound")
+  expect_error(
+    within_bounds("tree", "zoo")(2),
+    "bounds must only be checked on numerics or classes that are similar"
+  )
 })
 
 test_that("returned predicate works appropriately on scalars", {
@@ -86,6 +91,28 @@ test_that("returned predicate works appropriately on scalars", {
   expect_equal(within_bounds(0, Inf)(10), TRUE)
   expect_equal(within_bounds(0, Inf)(Inf), TRUE)
   expect_equal(within_bounds(0, Inf, include.upper=FALSE)(Inf), FALSE)
+
+  # Non-numeric classes
+  expect_equal(within_bounds(as.Date("2023-02-01"), as.Date("2023-02-05"))(as.Date("2023-02-03")), TRUE)
+  expect_equal(within_bounds(as.Date("2023-02-01"), as.Date("2023-02-05"))(as.Date("2023-02-06")), FALSE)
+  expect_equal(within_bounds("A", "D")("B"), TRUE)
+  expect_equal(within_bounds("A", "D")("Q"), FALSE)
+  # Classes that can be compared but are not generally similar
+  expect_equal(within_bounds(as.Date("2023-02-01"), as.numeric(as.Date("2023-02-05")), check.class=FALSE)(as.Date("2023-02-03")), TRUE)
+  expect_equal(within_bounds(as.Date("2023-02-01"), as.numeric(as.Date("2023-02-05")), check.class=FALSE)(as.Date("2023-02-06")), FALSE)
+  # Classes that shouldn't be compared but can be compared, if forced
+  expect_equal(
+    within_bounds(1, "tree", check.class=FALSE)(2),
+    TRUE
+  )
+  expect_equal(
+    within_bounds("tree", "zoo", check.class=FALSE)(2),
+    FALSE
+  )
+  expect_equal(
+    suppressWarnings(within_bounds("tree", "zoo", check.class=FALSE)(factor("A"))),
+    NA
+  )
 })
 
 test_that("returned predicate works appropriately on vectors", {


### PR DESCRIPTION
Fix #89

This allows any class to be used for `within_bounds()`.  The ability to compare is checked by either the fact that the two values are numeric or that they have an overlapping class.  The user can also disable the class comparison using `check.class = FALSE`.