### PR TITLE
Fix single row df case

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -120,9 +120,9 @@ assert <- function(data, predicate, ..., success_fun=success_continue,
                       return(apply.predicate.to.vector(this.vector,
                                                        predicate))})
   # special case for a single row data.frame
-  if(length(log.mat)==1 && !methods::is(log.mat, "matrix")){
+  if(!methods::is(log.mat, "matrix")){
     tmp <- names(log.mat)
-    log.mat <- matrix(data=log.mat)
+    log.mat <- matrix(data=log.mat, nrow=1)
     colnames(log.mat) <- tmp
   }
 

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -351,6 +351,17 @@ test_that("skip_chain_opts doesn't affect functionality outside chain for assert
                 "Column 'gear' violates assertion 'within_bounds\\(3.5, 4.5\\)' 20 times.*")
 })
 
+test_that("assert works with single row data.frames", {
+  single_row_data <- head(mtcars, 1)
+
+  expect_equal(assert(single_row_data, within_bounds(10,30), disp, error_fun = error_logical), FALSE)
+  expect_output(assert(single_row_data, within_bounds(10,30), disp, error_fun = just.show.error),
+               "Column 'disp' violates assertion 'within_bounds\\(10, 30\\)' 1 time.*")
+  expect_equal(assert(single_row_data, within_bounds(10,30), disp, mpg, error_fun = error_logical), FALSE)
+  expect_output(assert(single_row_data, within_bounds(10,30), disp, mpg, error_fun = just.show.error),
+               "Column 'disp' violates assertion 'within_bounds\\(10, 30\\)' 1 time.*")
+})
+
 ######################################
 
 


### PR DESCRIPTION
Fix #94 

With this change, `assert` will work for single-row data frames also in the case when there is more than one expression, e.g. `assert(single_row_data, within_bounds(10,30), disp, mpg)`.